### PR TITLE
Fix ruff 0.16 lint findings and drop isort

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,17 +17,17 @@
 ## Common Commands
 
 - **Run Tests**: `just test` or `uv run pytest`
-- **Format Code**: `just format` (runs `ruff` and `isort`)
-- **Lint Code**: `just lint` (runs `ruff check` and `isort --check-only`)
+- **Format Code**: `just format` (runs `ruff check --fix` and `ruff format`)
+- **Lint Code**: `just lint` (runs `ruff check` and `ruff format --check`)
 - **Clean Build**: `just clean`
 - **Check All**: `just check-clean` (verifies formatting and linting)
 
 ## Code Style & Conventions
 
 - **Language**: Python 3.14+
-- **Formatting**: Enforced by `ruff` and `isort`.
+- **Formatting**: Enforced by `ruff` (including import sorting).
 - **Line Length**: 100 characters (defined in `pyproject.toml`).
-- **Imports**: Sorted by `isort` (profile: black).
+- **Imports**: Sorted by ruff's isort rules.
 - **Type Hints**: Encouraged.
 
 ## Testing Instructions

--- a/justfile
+++ b/justfile
@@ -19,15 +19,13 @@ install-dev:
     uv pip install -e '.[dev]'
 
 # Code quality
-# Format code with ruff and isort
+# Format code with ruff (includes import sorting)
 format:
-    uvx isort .
     uvx ruff check . --fix
     uvx ruff format .
 
 # Run linting checks
 lint:
-    uvx isort . --check-only
     uvx ruff check .
     uvx ruff format --check .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dev = [
     "bump-my-version>=1.5.1",
     "coverage>=7.15.4",
     "hatchling>=1.31",
-    "isort>=8.0.1",
     "pytest>=9.1.1",
     "pytest-cov>=7.1",
     "pytest-timeout>=2.4.0",
@@ -68,14 +67,11 @@ include = ["src/kpf"]
 line-length = 100
 indent-width = 4
 format.indent-style = "space"
-target-version = "py310"
+target-version = "py314"
 src = ["src", "tests"]
 
-[tool.isort]
-profile = "black"
-multi_line_output = 3
-line_length = 100
-known_first_party = ["kpf"]
+[tool.ruff.lint.isort]
+known-first-party = ["src", "kpf"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/scripts/update_dependencies.py
+++ b/scripts/update_dependencies.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+import tomllib
 from collections.abc import Mapping
 from pathlib import Path
 
-import tomllib
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
@@ -336,7 +336,7 @@ def main() -> None:
     console.print(Panel.fit("Fleet Manager dependency update", style="bold magenta"))
 
     for tool in ("uv", "npm", "npx"):
-        if subprocess.run(["which", tool], capture_output=True).returncode != 0:
+        if subprocess.run(["which", tool], capture_output=True, check=False).returncode != 0:
             console.print(f"[bold red]Required tool not found:[/bold red] {tool}")
             raise SystemExit(1)
 

--- a/src/kpf/cli.py
+++ b/src/kpf/cli.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import argparse
 import importlib.resources
 import locale
@@ -286,7 +284,7 @@ def _debug_display_terminal_capabilities():
         console.print(
             f"[dim]Rich Console Size:[/dim] [green]{console_size.width}×{console_size.height}[/green]"
         )
-    except Exception:
+    except OSError, ValueError, AttributeError:
         pass
     console.print(
         f"[dim]stdin isatty:[/dim] [green]{getattr(sys.stdin, 'isatty', lambda: False)()}[/green]"
@@ -360,7 +358,7 @@ def _debug_display_terminal_capabilities():
         colors_value = colors.stdout.strip() or colors.stderr.strip()
         if colors_value:
             console.print(f"[dim]tput colors:[/dim] [green]{colors_value}[/green]")
-    except Exception:
+    except OSError, ValueError:
         pass
 
     # What box style will be used by our tables
@@ -383,7 +381,7 @@ def _debug_display_terminal_capabilities():
         for name, ch in samples.items():
             width = wcswidth(ch)
             console.print(f"  [dim]{name}[/dim]: '{ch}' -> [green]{width}[/green]")
-    except Exception:
+    except ImportError, OSError, ValueError:
         console.print("[dim]wcwidth:[/dim] [yellow]unavailable[/yellow]")
 
     console.print("[bold cyan]══════════════════════════════════════════════[/bold cyan]\n")
@@ -401,7 +399,7 @@ def _output_completion_script(shell: str) -> None:
         completions_pkg = importlib.resources.files("kpf.completions")
         script = (completions_pkg / filename).read_text()
         print(script)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         console.print(f"Error reading completion script: {e}", style="red")
         sys.exit(1)
 
@@ -498,10 +496,12 @@ def main():
                 sys.exit(0)
 
         # Apply the -0 flag if specified
-        if (args.address_zero or merged_config.get("alwaysListenAll", False)) and port_forward_args:
-            # Check if --address is already specified to avoid duplicates/conflicts
-            if "--address" not in port_forward_args:
-                port_forward_args.extend(["--address", "0.0.0.0"])
+        if (
+            (args.address_zero or merged_config.get("alwaysListenAll", False))
+            and port_forward_args
+            and "--address" not in port_forward_args
+        ):
+            port_forward_args.extend(["--address", "0.0.0.0"])
 
         # Run the port-forward utility (should only reach here if port_forward_args is set)
         if port_forward_args:
@@ -515,7 +515,7 @@ def main():
     except KeyboardInterrupt:
         console.print("\nOperation cancelled by user (Ctrl+C)", style="yellow")
         sys.exit(0)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         console.print(f"Error: {e}", style="red")
         sys.exit(1)
 
@@ -548,7 +548,7 @@ def history_main():
     except KeyboardInterrupt:
         console.print("\nOperation cancelled by user (Ctrl+C)", style="yellow")
         sys.exit(0)
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         console.print(f"Error: {e}", style="red")
         sys.exit(1)
 

--- a/src/kpf/config.py
+++ b/src/kpf/config.py
@@ -4,7 +4,7 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from rich.console import Console
 
@@ -15,7 +15,7 @@ class KpfConfig:
     """Configuration manager for kpf following XDG Base Directory Specification."""
 
     # Default configuration values
-    DEFAULTS = {
+    DEFAULTS: ClassVar[dict[str, Any]] = {
         "autoSelectFreePort": True,  # When 9090 is in use, try 9091, 9092, ...
         "showDirectCommand": True,
         "showDirectCommandIncludeContext": True,
@@ -100,7 +100,7 @@ class KpfConfig:
         except json.JSONDecodeError as e:
             console.print(f"[red]Error: Invalid JSON in config file {config_path}: {e}[/red]")
             console.print("[yellow]Using default configuration[/yellow]")
-        except Exception as e:
+        except OSError as e:
             console.print(
                 f"[yellow]Warning: Could not load config from {config_path}: {e}[/yellow]"
             )

--- a/src/kpf/config_wizard.py
+++ b/src/kpf/config_wizard.py
@@ -206,7 +206,7 @@ def run_config_wizard(config) -> None:
         try:
             with open(config_path) as f:
                 existing_raw = json.load(f)
-        except Exception:
+        except OSError, json.JSONDecodeError, TypeError:
             pass
 
     console.print()
@@ -291,5 +291,5 @@ def run_config_wizard(config) -> None:
             json.dump(changed, f, indent=2)
             f.write("\n")
         console.print(f"\n[green]Saved to {config_path}[/green]")
-    except Exception as e:
+    except OSError as e:
         console.print(f"[red]Error saving config: {e}[/red]")

--- a/src/kpf/connectivity.py
+++ b/src/kpf/connectivity.py
@@ -272,7 +272,7 @@ class ConnectivityChecker:
                     self.debug_print(f"HTTP connectivity test [red]SSL error: {url} -> {e}[/red]")
                 continue  # Try next URL
 
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 # Check if this is a non-HTTP protocol error
                 if self._is_non_http_protocol_error(e):
                     non_http_detected = True

--- a/src/kpf/display.py
+++ b/src/kpf/display.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import os
 import socket
 import subprocess
@@ -357,7 +355,12 @@ class ServiceSelector:
                                 "↑/↓ j/k=navigate  Enter=select  Esc=back  q=quit  digits=jump"
                             )
 
-                        def build_view():
+                        def build_view(
+                            current_index: int,
+                            *,
+                            max_index: int = max_index,
+                            help_text: str = help_text,
+                        ):
                             # Calculate a scrolling window so the selected row stays a few lines above bottom
                             terminal_height = self.console.size.height
                             overhead_lines = 8  # title, headers, borders, and help/legend
@@ -395,7 +398,7 @@ class ServiceSelector:
                             return Group(*renders)
 
                         with Live(
-                            build_view(),
+                            build_view(current_index),
                             console=self.console,
                             transient=True,
                             auto_refresh=False,
@@ -406,18 +409,18 @@ class ServiceSelector:
                                 if ch in (key.UP, "k"):
                                     current_index = max(1, current_index - 1)
                                     typed_number = ""
-                                    live.update(build_view(), refresh=True)
+                                    live.update(build_view(current_index), refresh=True)
                                 elif ch in (key.DOWN, "j"):
                                     current_index = min(max_index, current_index + 1)
                                     typed_number = ""
-                                    live.update(build_view(), refresh=True)
+                                    live.update(build_view(current_index), refresh=True)
                                 elif ch in (key.BACKSPACE, "\x7f", "\b"):
                                     typed_number = typed_number[:-1]
                                     if typed_number:
                                         preview = int(typed_number)
                                         if 1 <= preview <= max_index:
                                             current_index = preview
-                                    live.update(build_view(), refresh=True)
+                                    live.update(build_view(current_index), refresh=True)
                                 elif ch in (key.ENTER, "\r", "\n"):
                                     selection = current_index
                                     break
@@ -434,11 +437,11 @@ class ServiceSelector:
                                         typed_number, ch, max_index, current_index
                                     )
                                     if updated:
-                                        live.update(build_view(), refresh=True)
+                                        live.update(build_view(current_index), refresh=True)
                                 else:
                                     # ignore other keys
                                     pass
-                    except Exception:
+                    except Exception:  # noqa: BLE001
                         selection = None
 
                 # History menu requested — open it, then loop back if cancelled
@@ -605,7 +608,7 @@ class ServiceSelector:
                             else:
                                 # ignore other keys
                                 pass
-                except Exception:
+                except Exception:  # noqa: BLE001
                     selection = None
 
             # Fall back to numeric selection if interactive not used or cancelled
@@ -754,7 +757,7 @@ class ServiceSelector:
                                     live.update(build_view(), refresh=True)
                             else:
                                 pass
-                except Exception:
+                except Exception:  # noqa: BLE001
                     selection = None
 
             if selection is None:
@@ -981,7 +984,7 @@ class ServiceSelector:
                             else:
                                 # ignore other keys
                                 pass
-                except Exception:
+                except Exception:  # noqa: BLE001
                     selection = None
 
             # Fall back to numeric selection if interactive not used or cancelled

--- a/src/kpf/forwarder.py
+++ b/src/kpf/forwarder.py
@@ -182,22 +182,22 @@ class PortForwarder:
                     time.sleep(2)
 
                 # Test if port-forward is healthy (skip if health checks disabled)
-                if not self.no_health_check:
-                    if not self.connectivity_checker.test_port_forward_health(local_port):
-                        console.print("[red]Port-forward failed to start properly[/red]")
-                        console.print(
-                            "[yellow]This may indicate the service is not running or the port mapping is incorrect[/yellow]"
-                        )
-                        if proc:
-                            self.debug_print(
-                                f"Terminating failed port-forward process PID: {proc.pid}"
-                            )
-                            self._kill_proc(proc)
+                if (
+                    not self.no_health_check
+                    and not self.connectivity_checker.test_port_forward_health(local_port)
+                ):
+                    console.print("[red]Port-forward failed to start properly[/red]")
+                    console.print(
+                        "[yellow]This may indicate the service is not running or the port mapping is incorrect[/yellow]"
+                    )
+                    if proc:
+                        self.debug_print(f"Terminating failed port-forward process PID: {proc.pid}")
+                        self._kill_proc(proc)
 
-                        # Instead of shutting down immediately, set restart event to try again
-                        console.print("[yellow]Will retry port-forward in a moment...[/yellow]")
-                        self.restart_event.set()
-                        continue
+                    # Instead of shutting down immediately, set restart event to try again
+                    console.print("[yellow]Will retry port-forward in a moment...[/yellow]")
+                    self.restart_event.set()
+                    continue
 
                 console.print("\n🚀 [green]port-forward started[/green] 🚀")
 
@@ -350,7 +350,7 @@ class PortForwarder:
 
                 self.restart_event.clear()  # Reset the event for the next cycle
 
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 console.print(f"[red][Port-Forwarder] An error occurred: {e}[/red]")
                 self.terminate_process()
                 self.shutdown_event.set()
@@ -379,5 +379,5 @@ class PortForwarder:
                 proc.wait(timeout=0.5)
             except subprocess.TimeoutExpired:
                 pass
-        except Exception as e:
+        except OSError as e:
             self.debug_print(f"Error killing process: {e}")

--- a/src/kpf/history.py
+++ b/src/kpf/history.py
@@ -109,7 +109,7 @@ def load_history(folder: Path, limit: int = 20) -> list[HistoryEntry]:
                 grouped[key]["kubeconfig"] = kubeconfig
                 grouped[key]["listen_all"] = listen_all
 
-        except Exception:
+        except Exception:  # noqa: BLE001, S112
             continue
 
     now = time.time()

--- a/src/kpf/history_logger.py
+++ b/src/kpf/history_logger.py
@@ -2,7 +2,7 @@
 
 import json
 import time
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 
@@ -25,7 +25,7 @@ class HistoryLogger:
 
         self.session_data = {
             "start_time": time.time(),
-            "start_time_iso": datetime.now().isoformat(),
+            "start_time_iso": datetime.now(UTC).isoformat(),
             "service": None,
             "namespace": None,
             "context": None,
@@ -91,7 +91,7 @@ class HistoryLogger:
 
         self.session_data["exit_reason"] = exit_reason
         self.session_data["end_time"] = time.time()
-        self.session_data["end_time_iso"] = datetime.now().isoformat()
+        self.session_data["end_time_iso"] = datetime.now(UTC).isoformat()
         self.session_data["duration_seconds"] = (
             self.session_data["end_time"] - self.session_data["start_time"]
         )
@@ -107,13 +107,13 @@ class HistoryLogger:
             self.folder.mkdir(parents=True, exist_ok=True)
 
             # Use timestamp for filename
-            filename = f"session_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+            filename = f"session_{datetime.now(UTC).strftime('%Y%m%d_%H%M%S')}.json"
             filepath = self.folder / filename
 
             with open(filepath, "w") as f:
                 json.dump(self.session_data, f, indent=2)
 
-        except Exception as e:
+        except OSError as e:
             # Don't crash on logging errors, just print warning
             from rich.console import Console
 

--- a/src/kpf/kubernetes.py
+++ b/src/kpf/kubernetes.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import json
 import subprocess
 from dataclasses import dataclass
@@ -50,7 +48,7 @@ class KubernetesClient:
         """Check if kubectl is available."""
         try:
             subprocess.run(["kubectl", "version"], capture_output=True, check=True)
-        except (subprocess.CalledProcessError, FileNotFoundError):
+        except subprocess.CalledProcessError, FileNotFoundError:
             raise RuntimeError("kubectl is not available or not configured properly")
 
     def get_current_namespace(self) -> str:
@@ -88,7 +86,7 @@ class KubernetesClient:
                 check=False,
             )
             return result.stdout.strip() if result.returncode == 0 else ""
-        except Exception:
+        except OSError, subprocess.SubprocessError:
             return ""
 
     def get_all_namespaces(self) -> list[str]:
@@ -205,7 +203,7 @@ class KubernetesClient:
 
             return False
 
-        except (subprocess.CalledProcessError, json.JSONDecodeError):
+        except subprocess.CalledProcessError, json.JSONDecodeError:
             return False
 
     def get_pods_with_ports(self, namespace: str) -> list[ServiceInfo]:
@@ -250,7 +248,7 @@ class KubernetesClient:
 
             return sorted(pods_with_ports, key=lambda p: p.name)
 
-        except (subprocess.CalledProcessError, json.JSONDecodeError):
+        except subprocess.CalledProcessError, json.JSONDecodeError:
             # Return empty list if we can't get pods
             return []
 
@@ -296,6 +294,6 @@ class KubernetesClient:
 
             return sorted(deployments_with_ports, key=lambda d: d.name)
 
-        except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError):
+        except subprocess.CalledProcessError, json.JSONDecodeError, KeyError:
             # Return empty list if we can't get deployments
             return []

--- a/src/kpf/main.py
+++ b/src/kpf/main.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import os
 import re
 import signal
@@ -90,7 +88,7 @@ def get_watcher_args(port_forward_args, kubectl_global_flags=None):
         try:
             result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=5)
             namespace = result.stdout.strip() or "default"
-        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        except subprocess.CalledProcessError, subprocess.TimeoutExpired:
             namespace = "default"
         debug.print(f"No namespace specified, using current context namespace: '{namespace}'")
 
@@ -126,7 +124,6 @@ def run_port_forward(
         config: KpfConfig instance (optional)
         run_http_health_checks: Enable HTTP connectivity health checks (optional, default: False)
     """
-    global _sigint_count  # Keep existing sigint global but remove _debug_enabled global
     debug.enabled = debug_mode
 
     if debug_mode:
@@ -197,7 +194,7 @@ def run_port_forward(
 
             k8s = KubernetesClient()
             context = k8s.get_current_context()
-        except Exception:
+        except Exception:  # noqa: BLE001, S110
             pass
 
     # Detect listen_all from port_forward_args
@@ -205,7 +202,7 @@ def run_port_forward(
     try:
         addr_idx = port_forward_args.index("--address")
         listen_all = port_forward_args[addr_idx + 1] == "0.0.0.0"
-    except (ValueError, IndexError):
+    except ValueError, IndexError:
         pass
 
     # Resolve kubeconfig: explicit flag > KUBECONFIG env > default path

--- a/src/kpf/network_watchdog.py
+++ b/src/kpf/network_watchdog.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Network watchdog to detect zombie connections after laptop sleep/wake."""
 
 import socket
@@ -91,7 +90,7 @@ class NetworkWatchdog(threading.Thread):
                     f"Network watchdog: API server is {self._api_server_host}:{self._api_server_port}"
                 )
                 return self._api_server_host, self._api_server_port
-        except Exception as e:
+        except (OSError, ValueError, subprocess.SubprocessError) as e:
             self._debug(f"Network watchdog: Failed to get API server address: {e}")
 
         return None, 443
@@ -129,7 +128,7 @@ class NetworkWatchdog(threading.Thread):
         except socket.gaierror as e:
             self._debug(f"Network watchdog: DNS resolution failed for {host}: {e}")
             return False
-        except Exception as e:
+        except (OSError, ValueError) as e:
             self._debug(f"Network watchdog: Connection error to {host}:{port}: {e}")
             return False
 
@@ -166,7 +165,7 @@ class NetworkWatchdog(threading.Thread):
         except TimeoutError:
             self._debug(f"Network watchdog: Timeout connecting to local port {self.local_port}")
             return False
-        except Exception as e:
+        except (OSError, ValueError) as e:
             self._debug(f"Network watchdog: Error checking local port {self.local_port}: {e}")
             return False
 

--- a/src/kpf/validators.py
+++ b/src/kpf/validators.py
@@ -72,7 +72,7 @@ def validate_context(kubectl_global_flags):
         if kubeconfig:
             cmd.extend(["--kubeconfig", kubeconfig])
         try:
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=5)
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=5, check=False)
             if result.returncode != 0:
                 console.print(f"[red]Error: Context '{context}' not found[/red]")
                 error_msg = result.stderr.strip() if result.stderr else ""
@@ -96,7 +96,7 @@ def extract_local_port(port_forward_args):
             try:
                 local_port_str, _ = arg.split(":", 1)
                 return int(local_port_str)
-            except (ValueError, IndexError):
+            except ValueError, IndexError:
                 continue
     return None
 
@@ -144,7 +144,7 @@ def find_next_free_port(start_port: int, max_attempts: int = 10):
         port = start_port + offset
         if port > 65535:
             return None
-        is_available, error_reason = is_port_available(port)
+        is_available, _error_reason = is_port_available(port)
         # Only use ports that are truly available (not permission issues)
         if is_available:
             return port
@@ -181,7 +181,7 @@ def validate_port_format(port_forward_args):
 
                 return True
 
-            except (ValueError, IndexError):
+            except ValueError, IndexError:
                 console.print(
                     f"[red]Error: Invalid port format in '{arg}'. Expected format: 'local_port:remote_port' (e.g., 8080:80)[/red]"
                 )
@@ -203,6 +203,7 @@ def validate_kubectl_command(port_forward_args):
             capture_output=True,
             text=True,
             timeout=5,
+            check=False,
         )
 
         if result.returncode != 0:
@@ -265,7 +266,7 @@ def validate_kubectl_command(port_forward_args):
         console.print("[red]Error: kubectl command not found[/red]")
         console.print("[yellow]Please install kubectl and ensure it's in your PATH[/yellow]")
         return False
-    except Exception as e:
+    except (OSError, subprocess.SubprocessError, ValueError) as e:
         console.print(f"[red]Error: Failed to validate kubectl command: {e}[/red]")
         return False
 
@@ -300,7 +301,7 @@ def validate_service_and_endpoints(
             try:
                 result = subprocess.run(cmd, capture_output=True, text=True, check=True, timeout=5)
                 namespace = result.stdout.strip() or "default"
-            except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            except subprocess.CalledProcessError, subprocess.TimeoutExpired:
                 namespace = "default"
 
         # Find resource
@@ -362,7 +363,9 @@ def validate_service_and_endpoints(
                     "json",
                 ]
             )
-            result = subprocess.run(cmd_service, capture_output=True, text=True, timeout=10)
+            result = subprocess.run(
+                cmd_service, capture_output=True, text=True, timeout=10, check=False
+            )
 
             if result.returncode != 0:
                 error_msg = result.stderr.strip() if result.stderr else "Unknown error"
@@ -411,7 +414,9 @@ def validate_service_and_endpoints(
                     "json",
                 ]
             )
-            result = subprocess.run(cmd_endpoints, capture_output=True, text=True, timeout=10)
+            result = subprocess.run(
+                cmd_endpoints, capture_output=True, text=True, timeout=10, check=False
+            )
 
             if result.returncode != 0:
                 console.print(f"[red]Error: No endpoints found for service '{resource_name}'[/red]")
@@ -468,7 +473,7 @@ def validate_service_and_endpoints(
                 + kubectl_global_flags
                 + ["get", normalized_type, resource_name, "-n", namespace]
             )
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=10, check=False)
 
             if result.returncode != 0:
                 error_msg = result.stderr.strip() if result.stderr else "Unknown error"
@@ -487,7 +492,7 @@ def validate_service_and_endpoints(
         console.print("[red]Error: Service validation timed out[/red]")
         console.print("[yellow]This may indicate kubectl is not responding[/yellow]")
         return False
-    except Exception as e:
+    except (OSError, subprocess.SubprocessError, ValueError, KeyError, json.JSONDecodeError) as e:
         console.print(f"[red]Error: Failed to validate service: {e}[/red]")
         return False
 

--- a/src/kpf/watcher.py
+++ b/src/kpf/watcher.py
@@ -129,7 +129,7 @@ class EndpointWatcher:
                     )
                     time.sleep(2)
 
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 console.print(f"[red][Watcher] An error occurred: {e}[/red]")
                 self.terminate_process()
 
@@ -159,5 +159,5 @@ class EndpointWatcher:
                 proc.wait(timeout=0.5)
             except subprocess.TimeoutExpired:
                 pass
-        except Exception as e:
+        except OSError as e:
             self.debug_print(f"Error killing process: {e}")

--- a/test-pod/restart-test-app.py
+++ b/test-pod/restart-test-app.py
@@ -7,13 +7,13 @@ Perfect for testing kubectl port-forward functionality with kpf.
 
 import json
 import time
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse
 
 # Track when the container started
 START_TIME = time.time()
-START_DATETIME = datetime.now(timezone.utc)
+START_DATETIME = datetime.now(UTC)
 
 
 class UptimeHandler(BaseHTTPRequestHandler):
@@ -33,7 +33,7 @@ class UptimeHandler(BaseHTTPRequestHandler):
             "uptime_seconds": uptime_seconds,
             "uptime_human": self._format_uptime(uptime_seconds),
             "started_at": START_DATETIME.isoformat(),
-            "current_time": datetime.now(timezone.utc).isoformat(),
+            "current_time": datetime.now(UTC).isoformat(),
             "container_name": "kpf-test-app",
             "version": "1.0.0",
         }
@@ -210,7 +210,7 @@ app_uptime_seconds {uptime_seconds}
 
     def log_message(self, format, *args):
         """Log requests with timestamp."""
-        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+        timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
         print(f"[{timestamp}] {format % args}")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 from unittest.mock import Mock
 
 import pytest
+
 from src.kpf.kubernetes import KubernetesClient, ServiceInfo
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@
 from unittest.mock import ANY, Mock, patch
 
 import pytest
+
 from src.kpf.cli import create_parser, handle_prompt_mode, main, merge_config_with_cli_args
 
 

--- a/tests/test_completions.py
+++ b/tests/test_completions.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Tests to ensure shell completions stay in sync with CLI arguments."""
 
 import re
@@ -249,7 +248,7 @@ class TestCompletionFunctionality:
         for test_args in test_cases:
             try:
                 # Use parse_known_args to avoid SystemExit on -v/--version
-                args, _ = parser.parse_known_args(test_args)
+                _args, _ = parser.parse_known_args(test_args)
                 # If we got here, parsing succeeded
             except SystemExit as e:
                 # Version flag causes SystemExit(0), which is expected

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -5,6 +5,7 @@ import subprocess
 from unittest.mock import Mock, patch
 
 import pytest
+
 from src.kpf.display import ServiceSelector
 from src.kpf.kubernetes import ServiceInfo
 
@@ -291,9 +292,11 @@ class TestServiceSelector:
 
     def test_check_kubectl_not_found(self, mock_k8s_client):
         """Test _check_kubectl when kubectl is not found."""
-        with patch("subprocess.run", side_effect=FileNotFoundError):
-            with pytest.raises(RuntimeError, match="kubectl command not found"):
-                ServiceSelector(mock_k8s_client)
+        with (
+            patch("subprocess.run", side_effect=FileNotFoundError),
+            pytest.raises(RuntimeError, match="kubectl command not found"),
+        ):
+            ServiceSelector(mock_k8s_client)
 
     def test_check_kubectl_failed(self, mock_k8s_client):
         """Test _check_kubectl when kubectl command fails."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -25,6 +25,7 @@ class TestCLIIntegration:
             [sys.executable, "-m", "src.kpf.cli", "--help"],
             capture_output=True,
             text=True,
+            check=False,
         )
 
         assert result.returncode == 0
@@ -39,6 +40,7 @@ class TestCLIIntegration:
             [sys.executable, "-m", "src.kpf.cli", "--version"],
             capture_output=True,
             text=True,
+            check=False,
         )
 
         assert result.returncode == 0
@@ -71,9 +73,9 @@ class TestCLIIntegration:
         """Test that all modules can be imported without errors."""
         try:
             # Verify version consistency
+            import tomllib
             from pathlib import Path
 
-            import tomllib
             from src.kpf import __version__
             from src.kpf.cli import main
             from src.kpf.display import ServiceSelector
@@ -242,6 +244,7 @@ class TestErrorHandling:
             capture_output=True,
             text=True,
             timeout=15,  # Should fail fast, not timeout
+            check=False,
         )
 
         assert result.returncode == 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -814,6 +814,7 @@ class TestArgumentValidation:
             capture_output=True,
             text=True,
             timeout=10,
+            check=False,
         )
 
         assert result.returncode == 1
@@ -1058,6 +1059,7 @@ class TestServiceValidation:
             capture_output=True,
             text=True,
             timeout=15,
+            check=False,
         )
 
         assert result.returncode == 1
@@ -1161,6 +1163,7 @@ class TestConnectivityTesting:
     def test_test_http_connectivity_connection_error(self, mock_get):
         """Test HTTP connectivity test with connection error."""
         import requests
+
         from src.kpf.connectivity import ConnectivityChecker
 
         checker = ConnectivityChecker(run_http_health_checks=True)
@@ -1175,6 +1178,7 @@ class TestConnectivityTesting:
     def test_test_http_connectivity_timeout(self, mock_get):
         """Test HTTP connectivity test with timeout."""
         import requests
+
         from src.kpf.connectivity import ConnectivityChecker
 
         checker = ConnectivityChecker(run_http_health_checks=True)
@@ -1202,7 +1206,7 @@ class TestConnectivityTesting:
         mock_get.return_value = mock_response
 
         # First call
-        result1, description1 = checker._test_http_connectivity(8080)
+        result1, _description1 = checker._test_http_connectivity(8080)
         assert result1 == ConnectivityTestResult.SUCCESS
 
         # Second call should be rate limited
@@ -1615,6 +1619,7 @@ class TestContextAndKubeconfig:
             capture_output=True,
             text=True,
             timeout=15,
+            check=False,
         )
 
         assert result.returncode == 1

--- a/tests/test_network_watchdog.py
+++ b/tests/test_network_watchdog.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Tests for the network watchdog module."""
 
 import socket
@@ -80,7 +79,7 @@ class TestNetworkWatchdog:
     @patch("subprocess.run")
     def test_get_api_server_address_failure(self, mock_run):
         """Test handling of kubectl config failure."""
-        mock_run.side_effect = Exception("kubectl not found")
+        mock_run.side_effect = FileNotFoundError("kubectl not found")
 
         shutdown_event = threading.Event()
         restart_event = threading.Event()

--- a/uv.lock
+++ b/uv.lock
@@ -329,15 +329,6 @@ wheels = [
 ]
 
 [[package]]
-name = "isort"
-version = "8.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ef/7c/ec4ab396d31b3b395e2e999c8f46dec78c5e29209fac49d1f4dace04041d/isort-8.0.1.tar.gz", hash = "sha256:171ac4ff559cdc060bcfff550bc8404a486fee0caab245679c2abe7cb253c78d", size = 769592, upload-time = "2026-02-28T10:08:20.685Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/95/c7c34aa53c16353c56d0b802fba48d5f5caa2cdee7958acbcb795c830416/isort-8.0.1-py3-none-any.whl", hash = "sha256:28b89bc70f751b559aeca209e6120393d43fbe2490de0559662be7a9787e3d75", size = 89733, upload-time = "2026-02-28T10:08:19.466Z" },
-]
-
-[[package]]
 name = "kpf"
 version = "0.12.6"
 source = { editable = "." }
@@ -354,7 +345,6 @@ dev = [
     { name = "bump-my-version" },
     { name = "coverage" },
     { name = "hatchling" },
-    { name = "isort" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
@@ -375,7 +365,6 @@ dev = [
     { name = "bump-my-version", specifier = ">=1.5.1" },
     { name = "coverage", specifier = ">=7.15.4" },
     { name = "hatchling", specifier = ">=1.31" },
-    { name = "isort", specifier = ">=8.0.1" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "pytest-cov", specifier = ">=7.1" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },


### PR DESCRIPTION
## Summary
- Resolve ruff 0.16 default-rule findings (subprocess `check=False`, exception narrowing, shebang cleanup, timezone-aware datetimes, and related cleanups)
- Remove standalone `isort` and use ruff for import sorting via `just format` / `just lint`

## Test plan
- [ ] `just lint` passes
- [ ] `just test` passes
- [ ] CI RunTests / pre-commit green on this PR


Made with [Cursor](https://cursor.com)